### PR TITLE
Adding include that makes the intel compiler cry

### DIFF
--- a/src/communication/hpxreceiver.h
+++ b/src/communication/hpxreceiver.h
@@ -7,6 +7,7 @@
 #endif
 
 #include <hpx/include/components.hpp>
+#include <hpx/include/lcos.hpp>
 #include <hpx/lcos/broadcast.hpp>
 #include <hpx/lcos/local/receive_buffer.hpp>
 #include <hpx/runtime/get_ptr.hpp>
@@ -62,6 +63,20 @@ public:
         return ids;
     }
 
+    virtual ~HPXReceiver()
+    {}
+
+    void receive(std::size_t step, Cargo&& val)
+    {
+        buffer.store_received(step, std::forward<Cargo>(val));
+    }
+    HPX_DEFINE_COMPONENT_ACTION(HPXReceiver, receive, receiveAction);
+
+    hpx::future<Cargo> get(std::size_t step)
+    {
+        return buffer.receive(step);
+    }
+
     static std::vector<CARGO> allGather(
         const CARGO& data,
         std::size_t rank,
@@ -82,20 +97,6 @@ public:
         }
 
         return std::move(vec);
-    }
-
-    virtual ~HPXReceiver()
-    {}
-
-    void receive(std::size_t step, Cargo&& val)
-    {
-        buffer.store_received(step, std::forward<Cargo>(val));
-    }
-    HPX_DEFINE_COMPONENT_ACTION(HPXReceiver, receive, receiveAction);
-
-    hpx::future<Cargo> get(std::size_t step)
-    {
-        return buffer.receive(step);
     }
 
 private:

--- a/src/parallelization/hpxsimulator.cpp
+++ b/src/parallelization/hpxsimulator.cpp
@@ -10,9 +10,9 @@ std::map<std::string, hpx::lcos::local::promise<std::vector<double> > > localUpd
 std::map<std::string, hpx::lcos::local::promise<std::vector<double> > > myGlobalUpdateGroupSpeeds;
 std::map<std::string, hpx::lcos::local::promise<std::vector<std::size_t> > > myLocalityIndices;
 
-std::vector<double> getUpdateGroupSpeeds(const std::string& basename)
+hpx::future<std::vector<double> > getUpdateGroupSpeeds(const std::string& basename)
 {
-    return localUpdateGroupSpeeds[basename].get_future().get();
+    return localUpdateGroupSpeeds[basename].get_future();
 }
 
 void setNumberOfUpdateGroups(
@@ -31,10 +31,10 @@ HPX_PLAIN_ACTION(LibGeoDecomp::HpxSimulatorHelpers::getUpdateGroupSpeeds, getUpd
 HPX_PLAIN_ACTION(LibGeoDecomp::HpxSimulatorHelpers::setNumberOfUpdateGroups, setNumberOfUpdateGroups_action);
 
 HPX_REGISTER_BROADCAST_ACTION_DECLARATION(getUpdateGroupSpeeds_action)
-HPX_REGISTER_BROADCAST_ACTION_DECLARATION(setNumberOfUpdateGroups_action)
+HPX_REGISTER_BROADCAST_APPLY_ACTION_DECLARATION(setNumberOfUpdateGroups_action)
 
 HPX_REGISTER_BROADCAST_ACTION(getUpdateGroupSpeeds_action)
-HPX_REGISTER_BROADCAST_ACTION(setNumberOfUpdateGroups_action)
+HPX_REGISTER_BROADCAST_APPLY_ACTION(setNumberOfUpdateGroups_action)
 
 namespace LibGeoDecomp {
 namespace HpxSimulatorHelpers {
@@ -81,11 +81,11 @@ void gatherAndBroadcastLocalityIndices(
         }
         indices << indexSum;
 
-        hpx::lcos::broadcast<setNumberOfUpdateGroups_action>(
+        hpx::lcos::broadcast_apply<setNumberOfUpdateGroups_action>(
             localities,
             basename,
             flattenedUpdateGroupSpeeds,
-            indices).get();
+            indices);
     }
 
     *globalUpdateGroupSpeeds = myGlobalUpdateGroupSpeeds[basename].get_future().get();

--- a/src/parallelization/hpxsimulator.h
+++ b/src/parallelization/hpxsimulator.h
@@ -6,7 +6,9 @@
 
 #include <hpx/config.hpp>
 #include <hpx/runtime/serialization/set.hpp>
+#include <hpx/runtime/serialization/string.hpp>
 #include <hpx/runtime/serialization/vector.hpp>
+#include <hpx/include/lcos.hpp>
 #include <hpx/lcos/broadcast.hpp>
 
 #include <libgeodecomp/communication/hpxserializationwrapper.h>


### PR DESCRIPTION
Flyby:
    - using broadcast_apply to set updategroup indices
    - changing return value to avoid explicit get