### PR TITLE
Fixed order of includes

### DIFF
--- a/lib/libflatarray/include/libflatarray/detail/short_vec_scalar_double_1.hpp
+++ b/lib/libflatarray/include/libflatarray/detail/short_vec_scalar_double_1.hpp
@@ -18,16 +18,16 @@
 
 #include <cmath>
 
-#ifdef LIBFLATARRAY_WITH_CPP14
-#include <initializer_list>
-#endif
-
 #ifdef _MSC_BUILD
 #pragma warning( pop )
 #endif
 
 #include <libflatarray/config.h>
 #include <libflatarray/short_vec_base.hpp>
+
+#ifdef LIBFLATARRAY_WITH_CPP14
+#include <initializer_list>
+#endif
 
 namespace LibFlatArray {
 


### PR DESCRIPTION
LIBFLATARRAY_WITH_CPP14 is defined in libflatarray/config.h, so must not be used before config.h is included.